### PR TITLE
Path can now be provided via attribute macro.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/example/cql/queries/full_search_user.cql
+++ b/example/cql/queries/full_search_user.cql
@@ -1,0 +1,3 @@
+SELECT * FROM housemate.users_by_username
+WHERE lastname LIKE ?
+USING TIMEOUT 10000ms

--- a/example/cql/queries/get_group.cql
+++ b/example/cql/queries/get_group.cql
@@ -1,0 +1,2 @@
+SELECT * FROM housemate.groups
+WHERE id=?

--- a/example/cql/queries/get_user.cql
+++ b/example/cql/queries/get_user.cql
@@ -1,0 +1,2 @@
+SELECT * FROM housemate.users
+WHERE id=?

--- a/example/cql/queries/instant_search_user.cql
+++ b/example/cql/queries/instant_search_user.cql
@@ -1,0 +1,4 @@
+SELECT * FROM housemate.users_by_username
+WHERE lastname LIKE ?
+LIMIT 5
+USING TIMEOUT 500ms

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,8 +1,11 @@
+use scylla::transport::errors::QueryError;
+use scylla::Session;
 use scylla_prepare_derive::PrepareScylla;
 use scylla::prepared_statement::PreparedStatement;
 
 
 #[derive(PrepareScylla)]
+#[path = "./../cql/queries/"]
 pub struct PreparedStatements {
     get_user: PreparedStatement,
     get_group: PreparedStatement,
@@ -11,5 +14,4 @@ pub struct PreparedStatements {
 
 #[tokio::main]
 async fn main() {
-
 }

--- a/scylla-prepare-derive/src/lib.rs
+++ b/scylla-prepare-derive/src/lib.rs
@@ -2,23 +2,37 @@
 extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Fields, Ident};
+use syn::{Attribute, Data, DeriveInput, Fields, Ident, Lit, Meta, parse_macro_input};
 
 #[proc_macro_derive(PrepareScylla)]
 pub fn prepare_scylla_derive(input: TokenStream) -> TokenStream {
     // Construct a representation of Rust code as a syntax tree
     // that we can manipulate
-    let ast: DeriveInput = syn::parse(input).unwrap();
+    let ast = parse_macro_input!(input as DeriveInput);
+    // Initialize a variable to store the path to your queries
+    let mut path = String::new();
+
     let name: Ident = ast.ident.clone();
-    let fields: Vec<Ident> = match_fields(ast);
+    let fields: Vec<Ident> = match_fields(&ast);
     println!("{:?}", name);
     println!("{:?}", fields);
 
+    // Iterate over the attributes of the struct to find the `path` attribute
+    for attr in &ast.attrs {
+        if attr.path().is_ident("path") {
+            match parse_path_attr(attr.clone()) {
+                Ok(p) => path = p,
+                Err(e) => panic!("Error parsing path attribute: {}", e),
+            }
+        }
+    }
+    println!("{:?}", path);
+
     // Build the trait implementation
-    write_code(name, fields)
+    write_code(name, fields, path)
 }
 
-fn match_fields(input: DeriveInput) -> Vec<Ident> {
+fn match_fields(input: &DeriveInput) -> Vec<Ident> {
     match &input.data {
         Data::Struct(value) => {
             match &value.fields {
@@ -37,7 +51,7 @@ fn match_fields(input: DeriveInput) -> Vec<Ident> {
     vec![]
 }
 
-fn write_code(name: Ident, field_names: Vec<Ident>) -> TokenStream {
+fn write_code(name: Ident, field_names: Vec<Ident>, path: String) -> TokenStream {
     let fields_init: proc_macro2::TokenStream = field_names.iter().map(|x| {
         quote! {
             #x: #x(session).await?,
@@ -45,7 +59,7 @@ fn write_code(name: Ident, field_names: Vec<Ident>) -> TokenStream {
     }).collect();
     let fields_functions: proc_macro2::TokenStream = field_names.iter().map(|x| {
         let ident_string = x.to_string();
-        let mut string: String = "../../../cql/queries/".to_string();
+        let mut string: String = path.to_string();
         string.push_str(&ident_string);
         string.push_str(".cql");
         quote! {
@@ -70,4 +84,17 @@ fn write_code(name: Ident, field_names: Vec<Ident>) -> TokenStream {
                 #fields_functions
     };
     gen.into()
+}
+
+// Function to parse the `path` attribute
+fn parse_path_attr(attr: Attribute) -> Result<String, String> {
+    let meta = attr.meta;
+    if let Meta::NameValue(meta_name_value) = meta {
+        if let syn::Expr::Lit(expr_lit) = meta_name_value.value {
+            if let Lit::Str(lit_str) = &expr_lit.lit {
+                return Ok(lit_str.value());
+            }
+        }
+    }
+    Err("Attribute format is incorrect".to_string())
 }


### PR DESCRIPTION
Now supports path argument as an attribute macro, e.g.

#[derive(PrepareScylla)]
#[path = "./../cql/queries/"] // Pass arg in this form. 
pub struct PreparedStatements {
    get_user: PreparedStatement,
    get_group: PreparedStatement,
    }